### PR TITLE
People tracking ESP32 code

### DIFF
--- a/people-tracker/CMakeLists.txt
+++ b/people-tracker/CMakeLists.txt
@@ -1,0 +1,11 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.5)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS
+    ../components
+)
+
+project(spi-slave-sender)

--- a/people-tracker/CMakeLists.txt
+++ b/people-tracker/CMakeLists.txt
@@ -8,4 +8,4 @@ set(EXTRA_COMPONENT_DIRS
     ../components
 )
 
-project(spi-slave-sender)
+project(people-tracker)

--- a/people-tracker/Makefile
+++ b/people-tracker/Makefile
@@ -1,0 +1,9 @@
+#
+# This is a project Makefile. It is assumed the directory this Makefile resides in is a
+# project subdirectory.
+#
+
+PROJECT_NAME := spi-slave-sender
+
+include $(IDF_PATH)/make/project.mk
+

--- a/people-tracker/Makefile
+++ b/people-tracker/Makefile
@@ -1,9 +1,0 @@
-#
-# This is a project Makefile. It is assumed the directory this Makefile resides in is a
-# project subdirectory.
-#
-
-PROJECT_NAME := spi-slave-sender
-
-include $(IDF_PATH)/make/project.mk
-

--- a/people-tracker/README.md
+++ b/people-tracker/README.md
@@ -1,0 +1,17 @@
+# People tracker
+
+This demo application recieves tracklets from the [Gen2 People tracker](https://github.com/luxonis/depthai-experiments/tree/master/gen2-people-tracker) script over SPI.
+
+## Demo
+
+
+## Run this example
+First run the [Gen2 People tracker](https://github.com/luxonis/depthai-experiments/tree/master/gen2-people-tracker) script with `-spi` argument
+```
+python3 ~/depthai-experiments/gen2-people-tracker/main.py -spi
+```
+
+Then, flash the application to the ESP32 and open the monitor
+```
+idf.py -p PORT flash monitor
+```

--- a/people-tracker/main/CMakeLists.txt
+++ b/people-tracker/main/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Create library
+set(SOURCES
+    app_main.cpp
+)
+
+set(INCLUDE_DIRS  
+    .
+)
+
+idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS ${INCLUDE_DIRS} REQUIRES depthai-spi-api)

--- a/people-tracker/main/CMakeLists.txt
+++ b/people-tracker/main/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOURCES
     app_main.cpp
 )
 
-set(INCLUDE_DIRS  
+set(INCLUDE_DIRS
     .
 )
 

--- a/people-tracker/main/app_main.cpp
+++ b/people-tracker/main/app_main.cpp
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "decode_raw_mobilenet.h"
+#include "esp32_spi_impl.h"
+
+#include "spi_api.hpp"
+
+extern "C" {
+   void app_main();
+}
+
+const std::string status[4] = {"New", "Tracked", "Lost", "Removed"};
+
+void run_demo(){
+    uint8_t req_success = 0;
+
+    dai::SpiApi mySpiApi;
+    mySpiApi.set_send_spi_impl(&esp32_send_spi);
+    mySpiApi.set_recv_spi_impl(&esp32_recv_spi);
+
+
+    while(1) {
+        // ----------------------------------------
+        // basic example of receiving tracklets from the MyriadX
+        // ----------------------------------------
+        dai::Message msg;
+        if(mySpiApi.req_message(&msg, "tracklets")){
+            // example of parsing the raw metadata
+            dai::RawTracklets tracklets;
+            mySpiApi.parse_metadata(&msg.raw_meta, tracklets);
+            for(const auto& t : tracklets.tracklets){
+                printf("ID: %d, Status: %s, xmin: %f, ymin: %f, xmax: %f, ymax: %f\n",
+                    t.id, status[(std::int32_t)t.status].c_str(),
+                    t.srcImgDetection.xmin, t.srcImgDetection.ymin,
+                    t.srcImgDetection.xmax, t.srcImgDetection.ymax);
+            }
+
+            // free up resources once you're done with the message.
+            mySpiApi.free_message(&msg);
+        }
+
+        // ----------------------------------------
+        // pop current message/metadata. this tells the depthai to update the info being passed back using the spi_cmds.
+        // ----------------------------------------
+        req_success = mySpiApi.spi_pop_messages();
+    }
+}
+
+//Main application
+void app_main()
+{
+    // init spi for the esp32
+    init_esp32_spi();
+
+    run_demo();
+
+    //Never reached.
+    deinit_esp32_spi();
+}

--- a/people-tracker/main/app_main.cpp
+++ b/people-tracker/main/app_main.cpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stddef.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstddef>
+#include <cstring>
 
 #include "decode_raw_mobilenet.h"
 #include "esp32_spi_impl.h"

--- a/people-tracker/main/component.mk
+++ b/people-tracker/main/component.mk
@@ -1,0 +1,8 @@
+#
+# Main component makefile.
+#
+# This Makefile can be left empty. By default, it will take the sources in the 
+# src/ directory, compile them and link them into lib(subdirectory_name).a 
+# in the build directory. This behaviour is entirely configurable,
+# please read the ESP-IDF documents if you need to do this.
+#

--- a/people-tracker/main/component.mk
+++ b/people-tracker/main/component.mk
@@ -1,8 +1,0 @@
-#
-# Main component makefile.
-#
-# This Makefile can be left empty. By default, it will take the sources in the 
-# src/ directory, compile them and link them into lib(subdirectory_name).a 
-# in the build directory. This behaviour is entirely configurable,
-# please read the ESP-IDF documents if you need to do this.
-#


### PR DESCRIPTION
app currently prints tracklet information to the console.

**TODO:**
- Decode movement into left/right/up/down as in python script (bonus points if decoding is done in script node and just results are forwarded to host via xlink / esp32 via SPI)
- Send movements over https/mqtt to azure/aws/gcp